### PR TITLE
fix(scroll): improve smooth scrolling and robustness across site

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -25,6 +25,25 @@ const footerLinks = {
 
 export default function Footer() {
   const lenis = useLenis()
+
+  // Native fallback smooth scroll (easeInOutSine)
+  const smoothScrollToTop = (duration = 1200) => {
+    const start = window.scrollY || window.pageYOffset
+    const startTime = performance.now()
+
+    const easeInOutSine = (t: number) => 0.5 - Math.cos(Math.PI * t) / 2
+
+    function step(now: number) {
+      const elapsed = now - startTime
+      const progress = Math.min(1, elapsed / duration)
+      const eased = easeInOutSine(progress)
+      const y = Math.round(start * (1 - eased))
+      window.scrollTo(0, y)
+      if (progress < 1) requestAnimationFrame(step)
+    }
+
+    requestAnimationFrame(step)
+  }
   return (
     <footer className="relative bg-card border-t border-border">
       {/* Background effects */}
@@ -38,7 +57,15 @@ export default function Footer() {
           href="#"
           onClick={(e) => {
             e.preventDefault()
-            lenis?.scrollTo(0, { duration: 1.5 })
+            if ((lenis as any)?.scrollTo) {
+              try {
+                ;(lenis as any).scrollTo(0, { duration: 2.5, easing: (t: number) => 0.5 - Math.cos(Math.PI * t) / 2 })
+              } catch {
+                ;(lenis as any).scrollTo(0, { duration: 2.5 })
+              }
+            } else {
+              smoothScrollToTop(1200)
+            }
           }}
           className="group w-12 h-12 bg-primary text-primary-foreground rounded-full flex items-center justify-center transition-all duration-500 hover:shadow-[0_0_30px_rgba(0,255,136,0.6)] hover:-translate-y-2 hover:scale-110"
           aria-label="Back to top"

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -200,7 +200,12 @@ export default function HeroSection() {
             href="#about"
             onClick={(e) => {
               e.preventDefault()
-              lenis?.scrollTo("#about", { duration: 1.2 })
+              if ((lenis as any)?.scrollTo) {
+                ;(lenis as any).scrollTo("#about", { duration: 1.2 })
+              } else {
+                const target = document.getElementById("about")
+                if (target) target.scrollIntoView({ behavior: "smooth" })
+              }
             }}
             className="flex flex-col items-center gap-2 text-muted-foreground hover:text-primary transition-colors duration-300 group"
           >


### PR DESCRIPTION
- Expose Lenis instance via context (useLenis hook) in components/providers/smooth-scroll-provider.tsx
- Cancel RAF properly to avoid duplicate loops and stuck scrolling
- Remove native CSS smooth scrolling and add Lenis-recommended CSS in app/globals.css
- Move horizontal overflow handling to body to prevent double scrollbars
- Wire Hero 'Scroll to explore' and Footer 'Back to top' to use Lenis.scrollTo with durations
- Add native requestAnimationFrame fallback and easing for scroll-to-top when Lenis is not ready
- Adjust durations/easing for a smoother, gradual scroll experience